### PR TITLE
added async http request and removed old sync impl

### DIFF
--- a/src/main/java/com/limechain/teavm/HttpRequest.java
+++ b/src/main/java/com/limechain/teavm/HttpRequest.java
@@ -1,8 +1,32 @@
 package com.limechain.teavm;
 
+import org.teavm.interop.Async;
+import org.teavm.interop.AsyncCallback;
 import org.teavm.jso.JSBody;
+import org.teavm.jso.JSFunctor;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.core.JSError;
+
+import java.io.IOException;
 
 public class HttpRequest {
-    @JSBody(params = {"method", "url", "body"}, script = "return httpRequestSync(method, url, body);")
-    public static native String httpRequestSync(String method, String url, String body);
+    @JSFunctor
+    interface HttpRequestCallback extends JSObject {
+        void apply(JSError error, String response);
+    }
+
+    @Async
+    public static native String asyncHttpRequest(String method, String url, JSObject body);
+    private static void asyncHttpRequest(String method, String url, JSObject body, AsyncCallback<String> callback) {
+        createAsyncHttpRequest(method, url, body, (error, response) -> {
+            if (error != null) {
+                callback.error(new IOException(error.getMessage()));
+            } else {
+                callback.complete(response);
+            }
+        });
+    }
+
+    @JSBody(params = {"method", "url", "body", "callback"}, script = "return asyncHttpRequest(method, url, body, callback);")
+    public static native void createAsyncHttpRequest(String method, String url, JSObject body, HttpRequestCallback callback);
 }

--- a/src/main/java/com/limechain/teavm/HttpRequest.java
+++ b/src/main/java/com/limechain/teavm/HttpRequest.java
@@ -1,5 +1,6 @@
 package com.limechain.teavm;
 
+import lombok.extern.java.Log;
 import org.teavm.interop.Async;
 import org.teavm.interop.AsyncCallback;
 import org.teavm.jso.JSBody;
@@ -7,20 +8,18 @@ import org.teavm.jso.JSFunctor;
 import org.teavm.jso.JSObject;
 import org.teavm.jso.core.JSError;
 
-import java.io.IOException;
+import java.util.logging.Level;
 
+@Log
 public class HttpRequest {
-    @JSFunctor
-    interface HttpRequestCallback extends JSObject {
-        void apply(JSError error, String response);
-    }
 
     @Async
-    public static native String asyncHttpRequest(String method, String url, JSObject body);
-    private static void asyncHttpRequest(String method, String url, JSObject body, AsyncCallback<String> callback) {
+    public static native String asyncHttpRequest(String method, String url, String body);
+
+    private static void asyncHttpRequest(String method, String url, String body, AsyncCallback<String> callback) {
         createAsyncHttpRequest(method, url, body, (error, response) -> {
             if (error != null) {
-                callback.error(new IOException(error.getMessage()));
+                log.log(Level.WARNING, error.getMessage());
             } else {
                 callback.complete(response);
             }
@@ -28,5 +27,10 @@ public class HttpRequest {
     }
 
     @JSBody(params = {"method", "url", "body", "callback"}, script = "return asyncHttpRequest(method, url, body, callback);")
-    public static native void createAsyncHttpRequest(String method, String url, JSObject body, HttpRequestCallback callback);
+    public static native void createAsyncHttpRequest(String method, String url, String body, HttpRequestCallback callback);
+
+    @JSFunctor
+    private interface HttpRequestCallback extends JSObject {
+        void apply(JSError error, String response);
+    }
 }

--- a/src/main/java/com/limechain/utils/json/JsonUtil.java
+++ b/src/main/java/com/limechain/utils/json/JsonUtil.java
@@ -13,6 +13,6 @@ public class JsonUtil {
     }
 
     public static String readJsonFromFile(String filePath) {
-        return HttpRequest.httpRequestSync("GET", filePath, null);
+        return HttpRequest.asyncHttpRequest("GET", filePath, null);
     }
 }

--- a/src/main/java/com/limechain/utils/json/JsonUtil.java
+++ b/src/main/java/com/limechain/utils/json/JsonUtil.java
@@ -4,6 +4,9 @@ import com.limechain.teavm.HttpRequest;
 
 public class JsonUtil {
 
+    // Prevents instantiation
+    private JsonUtil() {}
+
     public static Object parseJson(String jsonString) {
         return new JsonParser(jsonString).parse();
     }

--- a/src/main/webapp/js/http.js
+++ b/src/main/webapp/js/http.js
@@ -1,15 +1,22 @@
-function httpRequestSync(method, url, body) {
-    var xhr = new XMLHttpRequest();
-    xhr.open(method, url, false); // false for synchronous request
-    xhr.setRequestHeader('Content-Type', 'application/json');
-    if (method === 'POST' && body) {
-        xhr.send(body);
-    } else {
-        xhr.send();
-    }
-    if (xhr.status === 200) {
-        return xhr.responseText;
-    } else {
-        throw new Error('Request failed with status ' + xhr.status);
+async function asyncHttpRequest(method = 'GET', url, body = null, callback) {
+    try {
+        const response = await fetch(url, {
+            method: method,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: method === 'POST' ? JSON.stringify(body) : undefined
+        });
+
+        if (!response.ok) {
+            callback(new Error(`Request failed with status: ${response?.status}`), null);
+            return;
+        }
+
+        let result = await response.text();
+        callback(null, result);
+
+    } catch (error) {
+        callback(new Error(`Error during sending request: ${error.message}`), null);
     }
 }

--- a/src/main/webapp/js/http.js
+++ b/src/main/webapp/js/http.js
@@ -5,7 +5,7 @@ async function asyncHttpRequest(method = 'GET', url, body = null, callback) {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: method === 'POST' ? JSON.stringify(body) : undefined
+            body: method === 'POST' ? body : undefined
         });
 
         if (!response.ok) {
@@ -13,10 +13,10 @@ async function asyncHttpRequest(method = 'GET', url, body = null, callback) {
             return;
         }
 
-        let result = await response.text();
+        const result = await response.text();
         callback(null, result);
 
     } catch (error) {
-        callback(new Error(`Error during sending request: ${error.message}`), null);
+        callback(new Error(`Error during sending request: ${error?.message}`), null);
     }
 }


### PR DESCRIPTION
# Description

In order to make http requests non-blocking the previous synchronous calls are replaced with asynchronous ones. Additionally, the new implementation in the http.js script utilizes async-await syntax, which is easier to understand than the old XMLHttpRequest approach.

What does this PR do?
Fixes https://github.com/LimeChain/Fruzhin/issues/506

How were these changes implemented and what do they affect?
Changes have been made to the HttpRequest class and http.js script, which are called by the JsonUtil class. These modifications will not be visible to all users of the JsonUtil class.