### PR TITLE
Feat: Fallback warp sync via RPC.

### DIFF
--- a/src/main/java/com/limechain/Main.java
+++ b/src/main/java/com/limechain/Main.java
@@ -2,10 +2,12 @@ package com.limechain;
 
 import com.limechain.client.HostNode;
 import com.limechain.client.LightClient;
-import com.limechain.config.HostConfig;
-import com.limechain.rpc.server.AppBean;
+import com.limechain.rpc.Function;
+import com.limechain.rpc.RpcClient;
 import com.limechain.rpc.server.RpcApp;
 import com.limechain.utils.DivLogger;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.core.JSString;
 
 import java.util.logging.Level;
 
@@ -20,9 +22,13 @@ public class Main {
 
         HostNode client = new LightClient();
 
+        exportAPI(RpcClient::sendRpcRequest, JSString.valueOf("rpc"));
         // Start the client
         // NOTE: This starts the beans the client would need - mutates the global context
         client.start();
         log.log(Level.INFO, "\uD83D\uDE80Started light client!");
     }
+
+    @JSBody(params = {"f", "apiName"}, script = "window[apiName] = f")
+    private static native void exportAPI(Function f, JSString apiName);
 }

--- a/src/main/java/com/limechain/Main.java
+++ b/src/main/java/com/limechain/Main.java
@@ -5,7 +5,6 @@ import com.limechain.client.LightClient;
 import com.limechain.rpc.Function;
 import com.limechain.rpc.RpcClient;
 import com.limechain.rpc.server.RpcApp;
-import com.limechain.storage.LocalStorage;
 import com.limechain.utils.DivLogger;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.core.JSString;
@@ -18,7 +17,6 @@ public class Main {
 
     public static void main(String[] args) {
         log.log("Starting LimeChain node...");
-        LocalStorage.clear();
         RpcApp rpcApp = new RpcApp();
         rpcApp.start();
 

--- a/src/main/java/com/limechain/Main.java
+++ b/src/main/java/com/limechain/Main.java
@@ -17,18 +17,20 @@ public class Main {
 
     public static void main(String[] args) {
         log.log("Starting LimeChain node...");
+        exportAPI(RpcClient::sendRpcRequest, JSString.valueOf("rpc"));
+
         RpcApp rpcApp = new RpcApp();
         rpcApp.start();
 
         HostNode client = new LightClient();
 
-        exportAPI(RpcClient::sendRpcRequest, JSString.valueOf("rpc"));
         // Start the client
         // NOTE: This starts the beans the client would need - mutates the global context
         client.start();
         log.log(Level.INFO, "\uD83D\uDE80Started light client!");
     }
 
-    @JSBody(params = {"f", "apiName"}, script = "window[apiName] = f")
+    @JSBody(params = {"f", "apiName"}, script = "window[apiName] = f;" +
+        "isRpcExported = true;")
     private static native void exportAPI(Function f, JSString apiName);
 }

--- a/src/main/java/com/limechain/Main.java
+++ b/src/main/java/com/limechain/Main.java
@@ -5,6 +5,7 @@ import com.limechain.client.LightClient;
 import com.limechain.rpc.Function;
 import com.limechain.rpc.RpcClient;
 import com.limechain.rpc.server.RpcApp;
+import com.limechain.storage.LocalStorage;
 import com.limechain.utils.DivLogger;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.core.JSString;
@@ -17,6 +18,7 @@ public class Main {
 
     public static void main(String[] args) {
         log.log("Starting LimeChain node...");
+        LocalStorage.clear();
         RpcApp rpcApp = new RpcApp();
         rpcApp.start();
 

--- a/src/main/java/com/limechain/client/LightClient.java
+++ b/src/main/java/com/limechain/client/LightClient.java
@@ -42,17 +42,15 @@ public class LightClient implements HostNode {
             this.network.updateCurrentSelectedPeer();
 
             if (this.network.getKademliaService().getSuccessfulBootNodes() > 0) {
-                System.out.println("Node successfully connected to a peer! Sync will use warp protocol!");
-                warpSyncMachine.start(false);
-                return;
+                warpSyncMachine.setProtocolSync(true);
+                break;
             } else {
                 retryCount++;
                 System.out.println("Waiting to retry peer connection...");
-                Thread.sleep(1000);
+                Thread.sleep(2000);
             }
         }
 
-        System.out.println("Node failed to connect to peer! Sync will use RPC calls!!");
-        warpSyncMachine.start(true);
+        warpSyncMachine.start();
     }
 }

--- a/src/main/java/com/limechain/client/LightClient.java
+++ b/src/main/java/com/limechain/client/LightClient.java
@@ -3,8 +3,8 @@ package com.limechain.client;
 import com.limechain.network.Network;
 import com.limechain.rpc.server.AppBean;
 import com.limechain.sync.warpsync.WarpSyncMachine;
+import com.limechain.utils.DivLogger;
 import lombok.SneakyThrows;
-import lombok.extern.java.Log;
 
 import java.util.logging.Level;
 
@@ -12,12 +12,12 @@ import java.util.logging.Level;
  * Main light client class that starts and stops execution of
  * the client and hold references to dependencies
  */
-@Log
 public class LightClient implements HostNode {
     // TODO: Add service dependencies i.e rpc, sync, network, etc.
     // TODO: Do we need those as fields here...?
     private final Network network;
-    private WarpSyncMachine warpSyncMachine;
+
+    private static final DivLogger log = new DivLogger();
 
     /**
      * @implNote the RpcApp is assumed to have been started before constructing the client,
@@ -33,16 +33,26 @@ public class LightClient implements HostNode {
     @SneakyThrows
     public void start() {
         this.network.start();
-        while (true) {
+        WarpSyncMachine warpSyncMachine = AppBean.getBean(WarpSyncMachine.class);
+
+        log.log(Level.INFO, "Syncing to latest finalized block state...");
+
+        int retryCount = 0;
+        while (retryCount < 3) {
             this.network.updateCurrentSelectedPeer();
+
             if (this.network.getKademliaService().getSuccessfulBootNodes() > 0) {
-                log.log(Level.INFO, "Node successfully connected to a peer! Sync can start!");
-                this.warpSyncMachine = AppBean.getBean(WarpSyncMachine.class);
-                this.warpSyncMachine.start();
-                break;
+                System.out.println("Node successfully connected to a peer! Sync will use warp protocol!");
+                warpSyncMachine.start(false);
+                return;
+            } else {
+                retryCount++;
+                System.out.println("Waiting to retry peer connection...");
+                Thread.sleep(1000);
             }
-            log.log(Level.INFO, "Waiting for peer connection...");
-            Thread.sleep(10000);
         }
+
+        System.out.println("Node failed to connect to peer! Sync will use RPC calls!!");
+        warpSyncMachine.start(true);
     }
 }

--- a/src/main/java/com/limechain/config/HostConfig.java
+++ b/src/main/java/com/limechain/config/HostConfig.java
@@ -5,6 +5,7 @@ import com.limechain.constants.RpcConstants;
 import com.limechain.utils.DivLogger;
 import lombok.Getter;
 
+import java.util.List;
 import java.util.logging.Level;
 
 /**
@@ -19,10 +20,10 @@ public class HostConfig {
     //    private final NodeRole nodeRole;
     private final String rpcNodeAddress;
 
-    private String polkadotGenesisPath = "genesis/polkadot.json";
-    private String kusamaGenesisPath = "genesis/ksmcc3.json";
-    private String westendGenesisPath = "genesis/westend2.json";
-    private String localGenesisPath = "genesis/westend-local.json";
+    private final String polkadotGenesisPath = "genesis/polkadot.json";
+    private final String kusamaGenesisPath = "genesis/ksmcc3.json";
+    private final String westendGenesisPath = "genesis/westend2.json";
+    private final String localGenesisPath = "genesis/westend-local.json";
 
     private static final DivLogger log = new DivLogger();
 
@@ -64,6 +65,15 @@ public class HostConfig {
             case KUSAMA -> kusamaGenesisPath;
             case WESTEND -> westendGenesisPath;
             case LOCAL -> localGenesisPath;
+        };
+    }
+
+    public List<String> getHttpsRpcEndpoints() {
+        return switch (chain) {
+            case POLKADOT -> RpcConstants.POLKADOT_HTTPS_RPC;
+            case KUSAMA -> RpcConstants.KUSAMA_HTTPS_RPC;
+            case WESTEND -> RpcConstants.WESTEND_HTTPS_RPC;
+            case LOCAL -> List.of();
         };
     }
 }

--- a/src/main/java/com/limechain/config/SystemInfo.java
+++ b/src/main/java/com/limechain/config/SystemInfo.java
@@ -1,12 +1,9 @@
 package com.limechain.config;
 
 import com.limechain.chain.Chain;
-import com.limechain.storage.block.SyncState;
 import com.limechain.utils.DivLogger;
 import lombok.Getter;
 
-import java.math.BigInteger;
-import java.util.Map;
 import java.util.logging.Level;
 
 /**
@@ -14,20 +11,18 @@ import java.util.logging.Level;
  */
 @Getter
 public class SystemInfo {
-//    private final String role;
+    //    private final String role;
     private final Chain chain;
-//    private final String hostIdentity;
+    //    private final String hostIdentity;
     private String hostName = "Fruzhin";
     private String hostVersion = "0.0.1";
-    private final BigInteger highestBlock;
 
     private static final DivLogger log = new DivLogger();
 
-    public SystemInfo(HostConfig hostConfig, SyncState syncState) {
+    public SystemInfo(HostConfig hostConfig) {
 //        this.role = network.getNodeRole().name();
         this.chain = hostConfig.getChain();
 //        this.hostIdentity = network.getHost().getPeerId().toString();
-        this.highestBlock = syncState.getLastFinalizedBlockNumber();
         logSystemInfo();
     }
 
@@ -48,6 +43,5 @@ public class SystemInfo {
 //        log.log(Level.INFO, authEmoji + "Role: " + role);
 //        log.log(Level.INFO, "Local node identity is: " + hostIdentity);
         log.log(Level.INFO, "Operating System: " + System.getProperty("os.name"));
-        log.log(Level.INFO, "Highest known block at #" + highestBlock);
     }
 }

--- a/src/main/java/com/limechain/constants/RpcConstants.java
+++ b/src/main/java/com/limechain/constants/RpcConstants.java
@@ -3,9 +3,27 @@ package com.limechain.constants;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RpcConstants {
     public static final String POLKADOT_WS_RPC = "wss://rpc.polkadot.io";
     public static final String KUSAMA_WS_RPC = "wss://kusama-rpc.polkadot.io";
     public static final String WESTEND_WS_RPC = "wss://westend-rpc.polkadot.io";
+
+    public static final List<String> POLKADOT_HTTPS_RPC = List.of(
+        "https://rpc.ibp.network/polkadot",
+        "https://polkadot-rpc.dwellir.com",
+        "https://rpc.polkadot.io"
+    );
+    public static final List<String> KUSAMA_HTTPS_RPC = List.of(
+        "https://rpc.ibp.network/kusama",
+        "https://kusama-rpc.dwellir.com",
+        "https://kusama-rpc.polkadot.io"
+    );
+    public static final List<String> WESTEND_HTTPS_RPC = List.of(
+        "https://rpc.ibp.network/westend",
+        "https://westend-rpc.dwellir.com",
+        "https://westend-rpc.polkadot.io"
+    );
 }

--- a/src/main/java/com/limechain/rpc/BlockRpcClient.java
+++ b/src/main/java/com/limechain/rpc/BlockRpcClient.java
@@ -1,0 +1,27 @@
+package com.limechain.rpc;
+
+import com.limechain.polkaj.Hash256;
+import com.limechain.rpc.dto.ChainGetHeaderResult;
+import com.limechain.rpc.dto.GrandpaRoundStateResult;
+import com.limechain.rpc.dto.RpcMethod;
+import com.limechain.rpc.dto.RpcResponse;
+
+import java.util.List;
+
+public final class BlockRpcClient extends RpcClient {
+
+    public static Hash256 getLastFinalizedBlockHash() {
+        RpcResponse response = sendRpcRequest(RpcMethod.CHAIN_GET_FINALIZED_HEAD, List.of());
+        return Hash256.from(getResult(response, String.class));
+    }
+
+    public static ChainGetHeaderResult getHeader(String blockHash) {
+        RpcResponse response = sendRpcRequest(RpcMethod.CHAIN_GET_HEADER, List.of(blockHash));
+        return getResult(response, ChainGetHeaderResult.class);
+    }
+
+    public static GrandpaRoundStateResult getGrandpaRoundState() {
+        RpcResponse response = sendRpcRequest(RpcMethod.GRANDPA_ROUND_STATE, List.of());
+        return getResult(response, GrandpaRoundStateResult.class);
+    }
+}

--- a/src/main/java/com/limechain/rpc/Function.java
+++ b/src/main/java/com/limechain/rpc/Function.java
@@ -1,0 +1,8 @@
+package com.limechain.rpc;
+
+import org.teavm.jso.JSObject;
+
+public interface Function extends JSObject {
+
+    String sendRequest(String method, String[] params);
+}

--- a/src/main/java/com/limechain/rpc/LoadBalancer.java
+++ b/src/main/java/com/limechain/rpc/LoadBalancer.java
@@ -1,0 +1,22 @@
+package com.limechain.rpc;
+
+import com.limechain.config.HostConfig;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class LoadBalancer {
+
+    private final List<String> endpoints;
+    private final AtomicInteger index;
+
+    public LoadBalancer(HostConfig hostConfig) {
+        this.endpoints = hostConfig.getHttpsRpcEndpoints();
+        this.index = new AtomicInteger(0);
+    }
+
+    public String getNextEndpoint() {
+        int currentIndex = index.getAndUpdate(i -> (i + 1) % endpoints.size());
+        return endpoints.get(currentIndex);
+    }
+}

--- a/src/main/java/com/limechain/rpc/RpcClient.java
+++ b/src/main/java/com/limechain/rpc/RpcClient.java
@@ -1,0 +1,45 @@
+package com.limechain.rpc;
+
+import com.limechain.config.HostConfig;
+import com.limechain.rpc.dto.RpcMethod;
+import com.limechain.rpc.dto.RpcRequest;
+import com.limechain.rpc.dto.RpcResponse;
+import com.limechain.rpc.server.AppBean;
+import com.limechain.teavm.HttpRequest;
+import com.limechain.utils.json.JsonUtil;
+import com.limechain.utils.json.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public sealed class RpcClient permits BlockRpcClient {
+
+    private static final String POST = "POST";
+
+    private static final AtomicInteger ID_COUNTER = new AtomicInteger(1);
+    private static final LoadBalancer LOAD_BALANCER = new LoadBalancer(AppBean.getBean(HostConfig.class));
+    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(false);
+
+    private static String createRpcRequestJson(String method, List<Object> params) {
+        RpcRequest request = new RpcRequest(ID_COUNTER.getAndAdd(1), method, params);
+        return JsonUtil.stringify(request);
+    }
+
+    protected static RpcResponse sendRpcRequest(RpcMethod method, List<Object> params) {
+        String jsonResult = HttpRequest.asyncHttpRequest(POST, LOAD_BALANCER.getNextEndpoint(),
+            createRpcRequestJson(method.getMethod(), params));
+        return OBJECT_MAPPER.mapToClass(jsonResult, RpcResponse.class);
+    }
+
+    protected static <T> T getResult(RpcResponse response, Class<T> type) {
+        if (response.getError() != null) {
+            throw new IllegalStateException("RPC request resulted in an error with code:" + response.getError().getCode()
+                + " and message:" + response.getError().getMessage());
+        }
+
+        return OBJECT_MAPPER.mapToClass(JsonUtil.stringify(response.getResult()), type);
+    }
+}

--- a/src/main/java/com/limechain/rpc/RpcClient.java
+++ b/src/main/java/com/limechain/rpc/RpcClient.java
@@ -28,7 +28,7 @@ public sealed class RpcClient permits BlockRpcClient {
         return JsonUtil.stringify(request);
     }
 
-    public static String sendRpcRequest(String method, String[] params) {
+    public static String sendRpcRequest(String method, Object[] params) {
         return HttpRequest.createHttpRequest(POST, LOAD_BALANCER.getNextEndpoint(),
             createRpcRequestJson(method, List.of(params)));
     }

--- a/src/main/java/com/limechain/rpc/RpcClient.java
+++ b/src/main/java/com/limechain/rpc/RpcClient.java
@@ -28,6 +28,11 @@ public sealed class RpcClient permits BlockRpcClient {
         return JsonUtil.stringify(request);
     }
 
+    public static String sendRpcRequest(String method, String[] params) {
+        return HttpRequest.createHttpRequest(POST, LOAD_BALANCER.getNextEndpoint(),
+            createRpcRequestJson(method, List.of(params)));
+    }
+
     protected static RpcResponse sendRpcRequest(RpcMethod method, List<Object> params) {
         String jsonResult = HttpRequest.asyncHttpRequest(POST, LOAD_BALANCER.getNextEndpoint(),
             createRpcRequestJson(method.getMethod(), params));

--- a/src/main/java/com/limechain/rpc/dto/ChainGetHeaderResult.java
+++ b/src/main/java/com/limechain/rpc/dto/ChainGetHeaderResult.java
@@ -1,0 +1,15 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+@Data
+@Reflectable
+public class ChainGetHeaderResult {
+
+    private String parentHash;
+    private String number;
+    private String stateRoot;
+    private String extrinsicsRoot;
+    private Digest digest;
+}

--- a/src/main/java/com/limechain/rpc/dto/Digest.java
+++ b/src/main/java/com/limechain/rpc/dto/Digest.java
@@ -1,0 +1,13 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Reflectable
+public class Digest {
+
+    private List<String> logs;
+}

--- a/src/main/java/com/limechain/rpc/dto/GrandpaRoundStateResult.java
+++ b/src/main/java/com/limechain/rpc/dto/GrandpaRoundStateResult.java
@@ -1,0 +1,15 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Reflectable
+public class GrandpaRoundStateResult {
+
+    private int setId;
+    private RoundState best;
+    private List<RoundState> background;
+}

--- a/src/main/java/com/limechain/rpc/dto/RoundState.java
+++ b/src/main/java/com/limechain/rpc/dto/RoundState.java
@@ -1,0 +1,14 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+@Data
+@Reflectable
+public class RoundState {
+    private int round;
+    private int totalWeight;
+    private int thresholdWeight;
+    private Votes prevotes;
+    private Votes precommits;
+}

--- a/src/main/java/com/limechain/rpc/dto/RpcError.java
+++ b/src/main/java/com/limechain/rpc/dto/RpcError.java
@@ -1,0 +1,13 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+@Data
+@Reflectable
+public class RpcError {
+
+    private int code;
+    private String message;
+    private String data;
+}

--- a/src/main/java/com/limechain/rpc/dto/RpcMethod.java
+++ b/src/main/java/com/limechain/rpc/dto/RpcMethod.java
@@ -1,0 +1,17 @@
+package com.limechain.rpc.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum RpcMethod {
+
+    CHAIN_GET_FINALIZED_HEAD("chain_getFinalizedHead"),
+    CHAIN_GET_HEADER("chain_getHeader"),
+    GRANDPA_ROUND_STATE("grandpa_roundState");
+
+    RpcMethod(String method) {
+        this.method = method;
+    }
+
+    private final String method;
+}

--- a/src/main/java/com/limechain/rpc/dto/RpcRequest.java
+++ b/src/main/java/com/limechain/rpc/dto/RpcRequest.java
@@ -1,0 +1,20 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Reflectable
+@NoArgsConstructor
+@AllArgsConstructor
+public class RpcRequest {
+
+    private int id;
+    private final String jsonrpc = "2.0";
+    private String method;
+    private List<Object> params;
+}

--- a/src/main/java/com/limechain/rpc/dto/RpcResponse.java
+++ b/src/main/java/com/limechain/rpc/dto/RpcResponse.java
@@ -1,0 +1,16 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Reflectable
+@NoArgsConstructor
+public class RpcResponse {
+
+    private int id;
+    private final String jsonrpc = "2.0";
+    private Object result;
+    private RpcError error;
+}

--- a/src/main/java/com/limechain/rpc/dto/Votes.java
+++ b/src/main/java/com/limechain/rpc/dto/Votes.java
@@ -1,0 +1,14 @@
+package com.limechain.rpc.dto;
+
+import com.limechain.teavm.annotation.Reflectable;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Reflectable
+public class Votes {
+
+    private int currentWeight;
+    private List<String> missing;
+}

--- a/src/main/java/com/limechain/rpc/server/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/server/CommonConfig.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 public class CommonConfig {
 
-    private static Map<Class<?>, Object> beans = new HashMap<>();
+    private static final Map<Class<?>, Object> beans = new HashMap<>();
 
     public static void start() {
         getBean(SystemInfo.class);
@@ -95,5 +95,4 @@ public class CommonConfig {
                                                    WarpSyncState warpSyncState) {
         return new WarpSyncMachine(network, chainService, syncState, warpSyncState);
     }
-
 }

--- a/src/main/java/com/limechain/rpc/server/CommonConfig.java
+++ b/src/main/java/com/limechain/rpc/server/CommonConfig.java
@@ -42,7 +42,7 @@ public class CommonConfig {
                     beans.put(beanClass, syncState);
                     return syncState;
                 case "SystemInfo":
-                    SystemInfo systemInfo = systemInfo((HostConfig) getBean(HostConfig.class), (SyncState) getBean(SyncState.class));
+                    SystemInfo systemInfo = systemInfo((HostConfig) getBean(HostConfig.class));
                     beans.put(beanClass, systemInfo);
                     return systemInfo;
                 case "Network":
@@ -79,8 +79,8 @@ public class CommonConfig {
         return new SyncState();
     }
 
-    private static SystemInfo systemInfo(HostConfig hostConfig, SyncState syncState) {
-        return new SystemInfo(hostConfig, syncState);
+    private static SystemInfo systemInfo(HostConfig hostConfig) {
+        return new SystemInfo(hostConfig);
     }
 
     private static Network network(ChainService chainService, HostConfig hostConfig) {

--- a/src/main/java/com/limechain/storage/DBConstants.java
+++ b/src/main/java/com/limechain/storage/DBConstants.java
@@ -22,6 +22,7 @@ public class DBConstants {
     public static final String LATEST_ROUND = "ss::latestRound";
     public static final String SET_ID = "ss::setId";
     public static final String STATE_ROOT = "ss::stateRoot";
+    public static final String IS_PROTOCOL_SYNC = "ss::isProtocolSync";
 
     //</editor-fold>
 }

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -33,6 +33,7 @@ public class SyncState {
     public SyncState() {
         this.genesisBlockHash = GenesisBlockHash.POLKADOT;
 
+        clearStoredStateIfNeeded();
         loadState();
         this.startingBlock = this.lastFinalizedBlockNumber;
     }
@@ -88,5 +89,16 @@ public class SyncState {
         this.setId = initState.getGrandpaAuthoritySet().getSetId();
         setAuthoritySet(initState.getGrandpaAuthoritySet().getCurrentAuthorities());
         finalizeHeader(initState.getFinalizedBlockHeader());
+    }
+
+    public void saveIsProtocolSync(boolean isProtocolSync) {
+        LocalStorage.save(DBConstants.IS_PROTOCOL_SYNC, isProtocolSync);
+    }
+
+    private void clearStoredStateIfNeeded() {
+        boolean isProtocolSync = LocalStorage.find(DBConstants.IS_PROTOCOL_SYNC, boolean.class).orElse(false);
+        if (!isProtocolSync) {
+            LocalStorage.clear();
+        }
     }
 }

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -14,7 +14,6 @@ import lombok.Setter;
 import lombok.extern.java.Log;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 
 @Getter
 @Log

--- a/src/main/java/com/limechain/storage/block/SyncState.java
+++ b/src/main/java/com/limechain/storage/block/SyncState.java
@@ -27,6 +27,7 @@ public class SyncState {
     @Setter
     private Authority[] authoritySet;
     private BigInteger latestRound;
+    @Setter
     private BigInteger setId;
 
     public SyncState() {
@@ -87,9 +88,5 @@ public class SyncState {
         this.setId = initState.getGrandpaAuthoritySet().getSetId();
         setAuthoritySet(initState.getGrandpaAuthoritySet().getCurrentAuthorities());
         finalizeHeader(initState.getFinalizedBlockHeader());
-    }
-
-    public String getStateRoot() {
-        return null;
     }
 }

--- a/src/main/java/com/limechain/sync/JustificationVerifier.java
+++ b/src/main/java/com/limechain/sync/JustificationVerifier.java
@@ -17,14 +17,6 @@ import org.teavm.jso.core.JSPromise;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.security.InvalidKeyException;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.security.SignatureException;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.X509EncodedKeySpec;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -49,7 +41,7 @@ public class JustificationVerifier {
 
         Set<Hash256> seenPublicKeys = new HashSet<>();
         Set<Hash256> authorityKeys =
-                Arrays.stream(authorities).map(Authority::getPublicKey).map(Hash256::new).collect(Collectors.toSet());
+            Arrays.stream(authorities).map(Authority::getPublicKey).map(Hash256::new).collect(Collectors.toSet());
 
         for (Precommit precommit : precommits) {
             if (!authorityKeys.contains(precommit.getAuthorityPublicKey())) {
@@ -68,9 +60,9 @@ public class JustificationVerifier {
             byte[] data = getDataToVerify(precommit, authoritiesSetId, round);
 
             boolean isValid = verifySignature(
-                    StringUtils.toHex(precommit.getAuthorityPublicKey().getBytes()),
-                    StringUtils.toHex(precommit.getSignature().getBytes()),
-                    StringUtils.toHex(data));
+                StringUtils.toHex(precommit.getAuthorityPublicKey().getBytes()),
+                StringUtils.toHex(precommit.getSignature().getBytes()),
+                StringUtils.toHex(data));
 
             if (!isValid) {
                 log.log(Level.WARNING, "Failed to verify signature");
@@ -142,7 +134,7 @@ public class JustificationVerifier {
     }
 
     @JSBody(params = {"publicKeyHex", "signatureHex",
-            "messageHex"}, script = "return verifyAsync(signatureHex, messageHex, publicKeyHex);")
+        "messageHex"}, script = "return verifyAsync(signatureHex, messageHex, publicKeyHex);")
     public static native JSPromise<JSBoolean> verifyAsync(String publicKeyHex, String signatureHex,
                                                           String messageHex);
 }

--- a/src/main/java/com/limechain/sync/warpsync/action/RequestFragmentsAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/RequestFragmentsAction.java
@@ -10,7 +10,6 @@ import lombok.extern.java.Log;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.logging.Level;
 
 @Log
@@ -38,7 +37,8 @@ public class RequestFragmentsAction implements WarpSyncAction {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 log.log(Level.SEVERE, "Retry warp sync request fragment exception: "
-                                      + e.getMessage(), e.getStackTrace());
+                    + e.getMessage(), e.getStackTrace());
+                sync.setWarpSyncAction(new RpcFallbackAction());
             }
         }
         if (this.result != null) {
@@ -50,8 +50,8 @@ public class RequestFragmentsAction implements WarpSyncAction {
 
     @Override
     public void handle(WarpSyncMachine sync) {
-        WarpSyncResponse resp = sync.getNetworkService().makeWarpSyncRequest(blockHash.toString());
         try {
+            WarpSyncResponse resp = sync.getNetworkService().makeWarpSyncRequest(blockHash.toString());
             if (resp == null) {
                 throw new MissingObjectException("No response received.");
             }
@@ -63,7 +63,7 @@ public class RequestFragmentsAction implements WarpSyncAction {
             }
             warpSyncState.setWarpSyncFragmentsFinished(resp.isFinished());
             sync.setFragmentsQueue(new ArrayDeque<>(
-                    Arrays.stream(resp.getFragments()).toList())
+                Arrays.stream(resp.getFragments()).toList())
             );
 
             this.result = resp;

--- a/src/main/java/com/limechain/sync/warpsync/action/RpcFallbackAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/RpcFallbackAction.java
@@ -1,0 +1,76 @@
+package com.limechain.sync.warpsync.action;
+
+import com.limechain.network.protocol.warp.dto.BlockHeader;
+import com.limechain.network.protocol.warp.dto.HeaderDigest;
+import com.limechain.network.protocol.warp.scale.reader.HeaderDigestReader;
+import com.limechain.polkaj.Hash256;
+import com.limechain.polkaj.reader.ScaleCodecReader;
+import com.limechain.rpc.BlockRpcClient;
+import com.limechain.rpc.dto.ChainGetHeaderResult;
+import com.limechain.rpc.dto.GrandpaRoundStateResult;
+import com.limechain.rpc.server.AppBean;
+import com.limechain.storage.block.SyncState;
+import com.limechain.sync.warpsync.WarpSyncMachine;
+import com.limechain.utils.StringUtils;
+import lombok.extern.java.Log;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.logging.Level;
+
+@Log
+public class RpcFallbackAction implements WarpSyncAction {
+    private final SyncState syncState;
+    private Exception error;
+
+    public RpcFallbackAction() {
+        this.syncState = AppBean.getBean(SyncState.class);
+    }
+
+    @Override
+    public void next(WarpSyncMachine sync) {
+        if (this.error != null) {
+            sync.setWarpSyncAction(new RequestFragmentsAction(syncState.getLastFinalizedBlockHash()));
+            return;
+        }
+
+        log.log(Level.INFO, "Populated sync state from RPC results. Block hash is now at #"
+            + syncState.getLastFinalizedBlockNumber() + ": "
+            + syncState.getLastFinalizedBlockHash().toString()
+            + " with state root " + syncState.getStateRoot());
+
+        sync.setWarpSyncAction(new FinishedAction());
+    }
+
+    @Override
+    public void handle(WarpSyncMachine sync) {
+        try {
+            Hash256 latestFinalizedHashResult = BlockRpcClient.getLastFinalizedBlockHash();
+            ChainGetHeaderResult headerResult = BlockRpcClient.getHeader(latestFinalizedHashResult.toString());
+            GrandpaRoundStateResult roundStateResult = BlockRpcClient.getGrandpaRoundState();
+
+            BlockHeader latestFinalizedHeader = new BlockHeader();
+            latestFinalizedHeader.setBlockNumber(new BigInteger(
+                StringUtils.remove0xPrefix(headerResult.getNumber()), 16));
+            latestFinalizedHeader.setParentHash(Hash256.from(headerResult.getParentHash()));
+            latestFinalizedHeader.setStateRoot(Hash256.from(headerResult.getStateRoot()));
+            latestFinalizedHeader.setExtrinsicsRoot(Hash256.from(headerResult.getExtrinsicsRoot()));
+
+            List<String> digestHexes = headerResult.getDigest().getLogs();
+            HeaderDigest[] digests = new HeaderDigest[digestHexes.size()];
+            for (int i = 0; i < digestHexes.size(); i++) {
+                digests[i] = new HeaderDigestReader().read(
+                    new ScaleCodecReader(StringUtils.hexToBytes(digestHexes.get(i))));
+            }
+            latestFinalizedHeader.setDigest(digests);
+
+            syncState.finalizeHeader(latestFinalizedHeader);
+            syncState.setSetId(BigInteger.valueOf(roundStateResult.getSetId()));
+            syncState.resetRound();
+
+        } catch (Exception e) {
+            log.log(Level.WARNING, "Error while calling rpc endpoints: " + e.getMessage());
+            this.error = e;
+        }
+    }
+}

--- a/src/main/java/com/limechain/sync/warpsync/action/RpcFallbackAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/RpcFallbackAction.java
@@ -68,6 +68,7 @@ public class RpcFallbackAction implements WarpSyncAction {
             syncState.setSetId(BigInteger.valueOf(roundStateResult.getSetId()));
             syncState.resetRound();
 
+            sync.setProtocolSync(false);
         } catch (Exception e) {
             log.log(Level.WARNING, "Error while calling rpc endpoints: " + e.getMessage());
             this.error = e;

--- a/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
+++ b/src/main/java/com/limechain/sync/warpsync/action/VerifyJustificationAction.java
@@ -28,7 +28,7 @@ public class VerifyJustificationAction implements WarpSyncAction {
     public void next(WarpSyncMachine sync) {
         if (this.error != null) {
             // Not sure what state we should transition to here.
-            sync.setWarpSyncAction(new FinishedAction());
+            sync.setWarpSyncAction(new RpcFallbackAction());
             return;
         }
 
@@ -52,8 +52,8 @@ public class VerifyJustificationAction implements WarpSyncAction {
                 throw new JustificationVerificationException("No such fragment");
             }
             boolean verified = JustificationVerifier.verify(
-                    fragment.getJustification().getPrecommits(),
-                    fragment.getJustification().getRound());
+                fragment.getJustification().getPrecommits(),
+                fragment.getJustification().getRound());
             if (!verified) {
                 throw new JustificationVerificationException("Justification could not be verified.");
             }
@@ -69,12 +69,12 @@ public class VerifyJustificationAction implements WarpSyncAction {
     private void handleAuthorityChanges(WarpSyncFragment fragment) {
         try {
             warpSyncState.handleAuthorityChanges(
-                    fragment.getHeader().getDigest(),
-                    fragment.getJustification().getTargetBlock());
+                fragment.getHeader().getDigest(),
+                fragment.getJustification().getTargetBlock());
             log.log(Level.INFO, "Verified justification. Block hash is now at #"
-                    + syncState.getLastFinalizedBlockNumber() + ": "
-                    + syncState.getLastFinalizedBlockHash().toString()
-                    + " with state root " + syncState.getStateRoot());
+                + syncState.getLastFinalizedBlockNumber() + ": "
+                + syncState.getLastFinalizedBlockHash().toString()
+                + " with state root " + syncState.getStateRoot());
         } catch (Exception e) {
             this.error = e;
         }

--- a/src/main/java/com/limechain/teavm/HttpRequest.java
+++ b/src/main/java/com/limechain/teavm/HttpRequest.java
@@ -27,7 +27,7 @@ public class HttpRequest {
     }
 
     @JSBody(params = {"method", "url", "body", "callback"}, script = "return asyncHttpRequest(method, url, body, callback);")
-    public static native void createAsyncHttpRequest(String method, String url, String body, HttpRequestCallback callback);
+    private static native void createAsyncHttpRequest(String method, String url, String body, HttpRequestCallback callback);
 
     @JSFunctor
     private interface HttpRequestCallback extends JSObject {

--- a/src/main/java/com/limechain/teavm/HttpRequest.java
+++ b/src/main/java/com/limechain/teavm/HttpRequest.java
@@ -17,7 +17,7 @@ public class HttpRequest {
     public static native String asyncHttpRequest(String method, String url, String body);
 
     private static void asyncHttpRequest(String method, String url, String body, AsyncCallback<String> callback) {
-        createAsyncHttpRequest(method, url, body, (error, response) -> {
+        createHttpRequest(method, url, body, (error, response) -> {
             if (error != null) {
                 log.log(Level.WARNING, error.getMessage());
             } else {
@@ -27,7 +27,10 @@ public class HttpRequest {
     }
 
     @JSBody(params = {"method", "url", "body", "callback"}, script = "return asyncHttpRequest(method, url, body, callback);")
-    private static native void createAsyncHttpRequest(String method, String url, String body, HttpRequestCallback callback);
+    private static native void createHttpRequest(String method, String url, String body, HttpRequestCallback callback);
+
+    @JSBody(params = {"method", "url", "body"}, script = "return httpRequestSync(method, url, body);")
+    public static native String createHttpRequest(String method, String url, String body);
 
     @JSFunctor
     private interface HttpRequestCallback extends JSObject {

--- a/src/main/java/com/limechain/utils/json/JsonUtil.java
+++ b/src/main/java/com/limechain/utils/json/JsonUtil.java
@@ -1,11 +1,11 @@
 package com.limechain.utils.json;
 
 import com.limechain.teavm.HttpRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class JsonUtil {
-
-    // Prevents instantiation
-    private JsonUtil() {}
 
     public static Object parseJson(String jsonString) {
         return new JsonParser(jsonString).parse();

--- a/src/main/java/com/limechain/utils/json/ObjectMapper.java
+++ b/src/main/java/com/limechain/utils/json/ObjectMapper.java
@@ -67,18 +67,18 @@ public class ObjectMapper {
         if (type.isInstance(value)) {
             return (T) value;
         } else if (type == Integer.class || type == int.class) {
-            return handleWholeNumber(value, (long) Integer.MIN_VALUE, (long) Integer.MIN_VALUE);
+            return handleWholeNumber(value, (long) Integer.MIN_VALUE, (long) Integer.MAX_VALUE);
         } else if (type == Long.class || type == long.class) {
             return handleWholeNumber(value, Long.MIN_VALUE, Long.MAX_VALUE);
         } else if (type == Double.class || type == double.class) {
-            BigDecimal bigDecimalValue = new BigDecimal((String) value);
+            BigDecimal bigDecimalValue = new BigDecimal(value.toString());
             double doubleValue = bigDecimalValue.doubleValue();
             if (doubleValue == Double.POSITIVE_INFINITY || doubleValue == Double.NEGATIVE_INFINITY) {
                 throw new ArithmeticException("Value out of range for Double: " + value);
             }
             return (T) Double.valueOf(doubleValue);
         } else if (type == BigInteger.class) {
-            return (T) new BigInteger((String) value);
+            return (T) new BigInteger(value.toString());
         } else if (type == Boolean.class || type == boolean.class) {
             return (T) value;
         } else if (type == String.class) {
@@ -91,6 +91,8 @@ public class ObjectMapper {
             }
         } else if (type.isArray()) {
             return (T) convertArray(type.getComponentType(), (List<?>) value);
+        } else if (Map.class.isAssignableFrom(value.getClass())) {
+            return mapToClass(JsonUtil.stringify(value), type);
         }
 
         throw new RuntimeException("Unsupported field type: " + type);
@@ -98,10 +100,10 @@ public class ObjectMapper {
 
     @SuppressWarnings("unchecked")
     private <T> T handleWholeNumber(Object value, Long min, Long max) {
-        BigInteger bigIntValue = new BigInteger((String) value);
+        BigInteger bigIntValue = new BigInteger(value.toString());
         if (bigIntValue.compareTo(BigInteger.valueOf(min)) < 0 ||
             bigIntValue.compareTo(BigInteger.valueOf(max)) > 0) {
-            throw new ArithmeticException("Value out of range number type: " + value);
+            throw new ArithmeticException("Value out of range for number type: " + value);
         }
         return (T) Integer.valueOf(bigIntValue.intValue());
     }

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -68,7 +68,11 @@
         //     stream.end();
         // });
     }
+    // Test
+    sendRpcRequest('system_name', []);
     main();
+    // Test 2
+    sendRpcRequest('chain_getBlock', []);
 </script>
 </body>
 </html>

--- a/src/main/webapp/js/http.js
+++ b/src/main/webapp/js/http.js
@@ -20,3 +20,19 @@ async function asyncHttpRequest(method = 'GET', url, body = null, callback) {
         callback(new Error(`Error during sending request: ${error?.message}`), null);
     }
 }
+
+function httpRequestSync(method, url, body) {
+    var xhr = new XMLHttpRequest();
+    xhr.open(method, url, false); // false for synchronous request
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    if (method === 'POST' && body) {
+        xhr.send(body);
+    } else {
+        xhr.send();
+    }
+    if (xhr.status === 200) {
+        return xhr.responseText;
+    } else {
+        throw new Error('Request failed with status ' + xhr.status);
+    }
+}

--- a/src/main/webapp/js/http.js
+++ b/src/main/webapp/js/http.js
@@ -36,3 +36,13 @@ function httpRequestSync(method, url, body) {
         throw new Error('Request failed with status ' + xhr.status);
     }
 }
+
+var isRpcExported = false;
+
+function sendRpcRequest(method, params) {
+    if (isRpcExported === false) {
+        window.setTimeout(() => sendRpcRequest(method, params), 10);
+    } else {
+        console.log(rpc.sendRequest(method, params));
+    }
+}


### PR DESCRIPTION
- What does this PR do?
Implements a fallback rpc action for the warp sync.
- Why are these changes needed?
In case the warp sync protocol is not working because of faulty peer nodes or another reason that would interfere with the warp execution.
- How were these changes implemented and what do they affect?
Another warp action is added, "RpcFallbackAction". It is reached if the warp sync cannot start initially or an issue occurs while requesting fragments of verifying justifications.

Fixes #494

## Checklist:
- [X] I have read the [contributing guidelines](https://github.com/LimeChain/Fruzhin/blob/dev/CONTRIBUTING.md).
- [X] My PR title matches the [Conventional Commits spec](https://www.conventionalcommits.org/).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.